### PR TITLE
keymap: spotlight key

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -22,7 +22,7 @@
    &kp TAB      &kp Q   &kp W       &kp E   &kp R       &kp T       &kp Y   &kp U   &kp I       &kp O       &kp P       &kp BSPC
    &kp LCTRL    &kp A   &kp S       &kp D   &kp F       &kp G       &kp H   &kp J   &kp K       &kp L       &kp SEMI    &kp SQT
    &kp LSHFT    &kp Z   &kp X       &kp C   &kp V       &kp B       &kp N   &kp M   &kp COMMA   &kp DOT     &kp FSLH    &kp ESC
-                        &kp LCMD    &mo 1   &kp SPACE   &kp RET   &mo 2   &kp RALT
+                        &kp LCMD    &mo 1   &kp SPACE   &kp RET     &mo 2   &kp RALT
                         >;
                 };
                 lower_layer {
@@ -34,7 +34,7 @@
                         bindings = <
    &kp TAB      &trans      &trans      &trans      &trans      &trans      &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4    &kp BSPC
    &kp LCTRL    &kp N1      &kp N2      &kp N3      &kp N4      &kp N5      &kp LEFT        &kp DOWN        &kp UP          &kp RIGHT       &trans          &bt BT_CLR
-   &kp LSHFT    &kp N6      &kp N7      &kp N8      &kp N9      &kp N0      &LG(SPACE)      &trans          &trans          &trans          &trans          &trans
+   &kp LSHFT    &kp N6      &kp N7      &kp N8      &kp N9      &kp N0      &kp LG(SPACE)      &trans          &trans          &trans          &trans          &trans
                             &kp LCMD    &trans      &kp SPACE   &kp RET     &trans          &kp RALT
                         >;
                 };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -22,20 +22,20 @@
    &kp TAB      &kp Q   &kp W       &kp E   &kp R       &kp T       &kp Y   &kp U   &kp I       &kp O       &kp P       &kp BSPC
    &kp LCTRL    &kp A   &kp S       &kp D   &kp F       &kp G       &kp H   &kp J   &kp K       &kp L       &kp SEMI    &kp SQT
    &kp LSHFT    &kp Z   &kp X       &kp C   &kp V       &kp B       &kp N   &kp M   &kp COMMA   &kp DOT     &kp FSLH    &kp ESC
-                        &kp LCMD    &mo 1   &kp RET     &kp SPACE   &mo 2   &kp RALT
+                        &kp LCMD    &mo 1   &kp SPACE   &kp RET   &mo 2   &kp RALT
                         >;
                 };
                 lower_layer {
 // -----------------------------------------------------------------------------------------
 // |  TAB |  1  |  2  |  3  |  4  |  5  |   | BT1 | BT2 | BT3 | BT4 | BT5 | BKSP |
 // | LCTRL| BT1 | BT2 | BT3 | BT4 | BT5 |   | LFT | DWN |  UP | RGT |     | BTCLR|
-// | SHFT |     |     |     |     |     |   |     |     |     |     |     |      |
-//                    | GUI |     | ENT |   | SPC |     | ALT |
+// | SHFT |     |     |     |     |     |   | SPOT|     |     |     |     |      |
+//                    | GUI |     | SPC |   | ENT |     | ALT |
                         bindings = <
    &kp TAB      &trans      &trans      &trans      &trans      &trans      &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4    &kp BSPC
    &kp LCTRL    &kp N1      &kp N2      &kp N3      &kp N4      &kp N5      &kp LEFT        &kp DOWN        &kp UP          &kp RIGHT       &trans          &bt BT_CLR
-   &kp LSHFT    &kp N6      &kp N7      &kp N8      &kp N9      &kp N0      &trans          &trans          &trans          &trans          &trans          &trans
-                            &kp LCMD    &trans      &kp RET     &kp SPACE   &trans          &kp RALT
+   &kp LSHFT    &kp N6      &kp N7      &kp N8      &kp N9      &kp N0      &LG(SPACE)      &trans          &trans          &trans          &trans          &trans
+                            &kp LCMD    &trans      &kp SPACE   &kp RET     &trans          &kp RALT
                         >;
                 };
 
@@ -44,12 +44,12 @@
 // |  TAB |     |     |     |     |     |   |     |     |     |     |     | BKSP |
 // | CTRL |  !  |  @  |  #  |  $  |  %  |   |  -  |  =  |  [  |  ]  |  \  |  `   |
 // | SHFT |  ^  |  &  |  *  |  (  |  )  |   |  _  |  +  |  {  |  }  | "|" |  ~   |
-//                    | GUI |     | ENT |   | SPC |     | ALT |
+//                    | GUI |     | SPC |   | ENT |     | ALT |
                         bindings = <
    &kp  TAB  &trans     &trans      &trans      &trans      &trans      &trans      &trans      &trans      &trans      &trans      &kp BSPC
    &kp LCTRL &kp EXCL   &kp AT      &kp HASH    &kp DLLR    &kp PRCNT   &kp MINUS   &kp EQUAL   &kp LBKT    &kp RBKT    &kp BSLH    &kp GRAVE
    &kp LSHFT &kp CARET  &kp AMPS    &kp ASTRK   &kp LPAR    &kp RPAR    &kp UNDER   &kp PLUS    &kp LBRC    &kp RBRC    &kp PIPE    &kp TILDE
-                        &kp LCMD    &trans      &kp RET     &kp SPACE   &trans      &kp RALT
+                        &kp LCMD    &trans      &kp SPACE   &kp RET   &trans      &kp RALT
                         >;
                 };
         };


### PR DESCRIPTION
adds a (test) keymap to trigger CMD+SPACE. this should restore the
space/enter keys while also allowing us to trigger spotlight with a key
from each split.